### PR TITLE
Bump numpy dependency

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,6 +106,7 @@ nitpick_ignore = [
     ("py:class", "numpy.array"),
     ("py:class", "ase.gui.gui.GUI"),
     ("py:class", "ase.gui.images.Images"),
+    ("py:class", "ase.atoms.Atoms"),
     ("py:class", "ipywidgets.GridspecLayout"),
     ("py:class", "pythreejs.Renderer"),
     ("py:class", "tkinter.Canvas"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,7 +106,6 @@ nitpick_ignore = [
     ("py:class", "numpy.array"),
     ("py:class", "ase.gui.gui.GUI"),
     ("py:class", "ase.gui.images.Images"),
-    ("py:class", "ase.atoms.Atoms"),
     ("py:class", "ipywidgets.GridspecLayout"),
     ("py:class", "pythreejs.Renderer"),
     ("py:class", "tkinter.Canvas"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,7 @@
 #
 # ase-notebook documentation build configuration file
 #
-# This file is execfile()d with the current directory set to its
+# This file is ``execfile()``d with the current directory set to its
 # containing dir.
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "ase>=3.18,<4",
         "attrs>=19,<20",
         "importlib_resources>=1,<2",
-        "numpy>=1.16.4,<1.17",
+        "numpy>=1.16.4,<1.19",
         # used for color-map
         # TODO use color-map package, with no matplotlib dependency?
         "matplotlib>=3.1,<4",


### PR DESCRIPTION
I checked this with numpy 1.16, 1.17 and 1.18 and all tests pass.

However the documentation build still makes problems and I don't know how to fix  this
```
/home/travis/build/PhilippRue/ase-notebook/ase_notebook/configuration.py:docstring of ase_notebook.configuration.ViewConfig::py:class reference target not found: Union[None, tuple]
490
```