### PR TITLE
Improve options for bond visualisation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             make
 
       - store_artifacts:
-          path: docs/_build/html/
+          path: docs/build/html/
           destination: html
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2
+jobs:
+  build_docs:
+    docker:
+      - image: circleci/python:3.6-stretch
+    steps:
+      # Get our data and merge with upstream
+      - run: sudo apt-get update
+      - checkout
+
+      - restore_cache:
+          keys:
+            - cache-pip
+
+      - run: |
+          pip install --user .[threejs,svgconcat,docs]
+          url="https://github.com/jgm/pandoc/releases/tag/2.6"
+          path=$(curl -L $url | grep -o '/jgm/pandoc/releases/download/.*-amd64\.deb')
+          downloadUrl="https://github.com$path"
+          file=${path##*/}
+          wget $downloadUrl && sudo dpkg -i $file
+
+      - save_cache:
+          key: cache-pip
+          paths:
+            - ~/.cache/pip
+
+      # Build the docs
+      - run:
+          name: Build docs to store
+          command: |
+            cd docs
+            make
+
+      - store_artifacts:
+          path: docs/_build/html/
+          destination: html
+
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build_docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,12 +35,12 @@
     exclude: docs/build/*
     name: doc8 - Lint the documentation.
 
-  - id: travis-linter
-    name: Travis Lint
-    entry: travis lint
-    files: .travis.yml
-    language: ruby
-    additional_dependencies: ['travis']
+  # - id: travis-linter
+  #   name: Travis Lint
+  #   entry: travis lint
+  #   files: .travis.yml
+  #   language: ruby
+  #   additional_dependencies: ['travis']
 
   # - id: conda
   #   name: Create environment.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
         env: TEST_TYPE="pytest" PYPI_DEPLOY=true
       - python: 3.7
         env: TEST_TYPE="pytest"
-      - python: 3.6
-        env: TEST_TYPE="docs" READTHEDOCS="True"
 
 install:
   - pip install --upgrade pip wheel setuptools
@@ -28,15 +26,6 @@ install:
         pip install -e .[threejs,testing]
         pip install coveralls
       fi
-  - |
-      if [[ "$TEST_TYPE" == "docs" ]]; then
-        pip install -e .[threejs,svgconcat,docs]
-        url="https://github.com/jgm/pandoc/releases/tag/2.6"
-        path=$(curl -L $url | grep -o '/jgm/pandoc/releases/download/.*-amd64\.deb')
-        downloadUrl="https://github.com$path"
-        file=${path##*/}
-        wget $downloadUrl && sudo dpkg -i $file
-      fi
 
 script:
 - |
@@ -47,11 +36,6 @@ script:
 - |
   if [[ "$TEST_TYPE" == "pre-commit" ]]; then
     pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
-  fi
-- |
-  if [[ "$TEST_TYPE" == "docs" ]]; then
-    cd docs
-    make
   fi
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI Status](https://travis-ci.org/chrisjsewell/ase-notebook.svg?branch=develop)](https://travis-ci.org/chrisjsewell/ase-notebook)
 [![Coverage](https://coveralls.io/repos/github/chrisjsewell/ase-notebook/badge.svg?branch=develop)](https://coveralls.io/github/chrisjsewell/ase-notebook?branch=develop)
+[![CircleCI](https://circleci.com/gh/chrisjsewell/ase-notebook.svg?style=svg)](https://circleci.com/gh/chrisjsewell/ase-notebook)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![RTD](https://readthedocs.org/projects/ase-notebook/badge)](http://ase-notebook.readthedocs.io/)
 [![PyPI](https://img.shields.io/pypi/v/ase-notebook.svg)](https://pypi.org/project/ase-notebook)

--- a/ase_notebook/__init__.py
+++ b/ase_notebook/__init__.py
@@ -10,4 +10,4 @@ except ImportError:
     # before dependencies are installed
     pass
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/ase_notebook/backend/svg.py
+++ b/ase_notebook/backend/svg.py
@@ -225,10 +225,10 @@ def create_axes_elements(
     font_offset=1.0,
     line_width=1,
     line_color="black",
+    labels=("X", "Y", "Z"),
+    colors=("red", "green", "blue"),
 ):
     """Create the SVG elements, related to the axes."""
-    rgb = ["red", "green", "blue"]
-
     svg_elements = []
 
     for i in axes[:, 2].argsort():
@@ -243,10 +243,10 @@ def create_axes_elements(
         )
         svg_elements.append(
             text.Text(
-                "XYZ"[i],
+                labels[i],
                 x=(e,),
                 y=(f,),
-                fill=rgb[i],
+                fill=colors[i],
                 text_anchor="middle",
                 dominant_baseline="middle",
                 font_size=font_size,

--- a/ase_notebook/configuration.py
+++ b/ase_notebook/configuration.py
@@ -25,14 +25,17 @@ def iterable_length(length):
     return _validate
 
 
-def in_range(minimum=None, maximum=None):
+def in_range(minimum=None, maximum=None, inclusive_min=True):
     """Validate that an attribute value is a number >= 0."""  # noqa: D202
 
     def _validate(self, attribute, value):
         raise_error = False
         if not isinstance(value, (int, float)):
             raise_error = True
-        elif minimum is not None and value < minimum:
+        elif minimum is not None and (
+            (inclusive_min and value < minimum)
+            or (not inclusive_min and value <= minimum)
+        ):
             raise_error = True
         elif maximum is not None and value > maximum:
             raise_error = True
@@ -282,6 +285,13 @@ class ViewConfig:
         validator=instance_of(bool),
         metadata={"help": "Show atomic bonds."},
     )
+    bond_radii_scale: float = attr.ib(
+        default=1.5,
+        validator=in_range(0.0, inclusive_min=False),
+        metadata={
+            "help": "Factor to scale atomic radii by, when computing bonds (via overlapping radii)"
+        },
+    )
     bond_array_name: Optional[str] = attr.ib(
         default=None,
         validator=optional(instance_of(str)),
@@ -368,7 +378,9 @@ class ViewConfig:
         },
     )
     axes_length: float = attr.ib(
-        default=15, validator=in_range(0), metadata={"help": "Length of axes lines."}
+        default=15,
+        validator=in_range(0, inclusive_min=False),
+        metadata={"help": "Length of axes lines."},
     )
     axes_font_size: int = attr.ib(
         default=14, validator=[instance_of(int), in_range(1)], metadata={"help": ""}
@@ -397,7 +409,9 @@ class ViewConfig:
     )
     canvas_crop: Union[list, tuple, None] = attr.ib(default=None, metadata={"help": ""})
     zoom: float = attr.ib(
-        default=1.0, validator=in_range(0), metadata={"help": "3D camera zoom."}
+        default=1.0,
+        validator=in_range(0, inclusive_min=False),
+        metadata={"help": "3D camera zoom."},
     )
     camera_fov: float = attr.ib(
         default=10.0,

--- a/ase_notebook/configuration.py
+++ b/ase_notebook/configuration.py
@@ -15,7 +15,7 @@ def iterable_length(length):
     def _validate(self, attribute, value):
         if not isinstance(value, Iterable) or len(value) != 2:
             raise TypeError(
-                f"'{attribute.name}' must be an interable of length {length} "
+                f"'{attribute.name}' must be an iterable of length {length} "
                 f"(got {value!r} that is a {value.__class__!r}).",
                 attribute,
                 Iterable,
@@ -407,7 +407,9 @@ class ViewConfig:
     canvas_background_opacity: float = attr.ib(
         default=0.0, validator=in_range(0, 1), metadata={"help": ""}
     )
-    canvas_crop: Union[list, tuple, None] = attr.ib(default=None, metadata={"help": ""})
+    canvas_crop: Union[list, tuple, None] = attr.ib(
+        default=None, metadata={"help": "Crop canvas: (left, right, top, bottom)"}
+    )
     zoom: float = attr.ib(
         default=1.0,
         validator=in_range(0, inclusive_min=False),

--- a/ase_notebook/configuration.py
+++ b/ase_notebook/configuration.py
@@ -191,7 +191,7 @@ class ViewConfig:
                 "value_array",
             )
         ),
-        metadata={"help": "Atom property to label atoms by."},
+        metadata={"help": "Atom property to color atoms by."},
     )
     atom_color_array: str = attr.ib(
         default="",
@@ -268,7 +268,7 @@ class ViewConfig:
             "help": "If True, and the atoms have been repeated, show each unit cell of the original atoms."
         },
     )
-    uc_dash_pattern: Union[None, tuple] = attr.ib(
+    uc_dash_pattern: Union[None, Tuple[float, float]] = attr.ib(
         default=None,
         metadata={"help": "A (length, gap) dash pattern for unit cell lines."},
     )
@@ -306,6 +306,32 @@ class ViewConfig:
         default=0.8,
         validator=in_range(0, 1),
         metadata={"help": "Opacity of atomic bond lines."},
+    )
+    bond_color_by: str = attr.ib(
+        default="atoms",
+        validator=in_(("atoms", "length")),
+        metadata={
+            "help": "How to color bond: 'atoms' (same as connecting atoms) or 'length'."
+        },
+    )
+    bond_colormap: str = attr.ib(
+        default="jet",
+        validator=instance_of(str),
+        metadata={
+            "help": ("The matplotlib colormap to use with ``bond_color_by='length'``")
+        },
+    )
+    bond_colormap_range: Union[list, tuple] = attr.ib(
+        default=(None, None),
+        validator=deep_iterable(
+            optional(instance_of((int, float))), iterable_length(2)
+        ),
+        metadata={
+            "help": (
+                "The matplotlib colormap normalisation use with "
+                "``bond_color_by='length'``"
+            )
+        },
     )
     show_miller_planes: bool = attr.ib(
         default=True, validator=instance_of(bool), metadata={"help": ""}
@@ -357,7 +383,7 @@ class ViewConfig:
     )
     canvas_size: Tuple[float, float] = attr.ib(
         default=(400, 400),
-        validator=deep_iterable(instance_of((int, float)), iterable_length(2)),
+        validator=deep_iterable(in_range(1), iterable_length(2)),
         metadata={"help": ""},
     )
     canvas_color_foreground: str = attr.ib(

--- a/ase_notebook/configuration.py
+++ b/ase_notebook/configuration.py
@@ -338,7 +338,7 @@ class ViewConfig:
         ),
         metadata={
             "help": (
-                "The matplotlib colormap normalisation use with "
+                "The matplotlib colormap normalisation to use with "
                 "``bond_color_by='length'``"
             )
         },

--- a/ase_notebook/configuration.py
+++ b/ase_notebook/configuration.py
@@ -1,12 +1,28 @@
 """A module for creating visualisations of a structure."""
-from collections import Mapping
+from collections import Iterable, Mapping
 from typing import Optional, Tuple, Union
 
 import attr
-from attr.validators import in_, instance_of, optional
+from attr.validators import deep_iterable, in_, instance_of, optional
 
 from .attr_doc import autodoc
 from .color import Color
+
+
+def iterable_length(length):
+    """Validate that an attribute is an iterable of a certain length."""  # noqa: D202
+
+    def _validate(self, attribute, value):
+        if not isinstance(value, Iterable) or len(value) != 2:
+            raise TypeError(
+                f"'{attribute.name}' must be an interable of length {length} "
+                f"(got {value!r} that is a {value.__class__!r}).",
+                attribute,
+                Iterable,
+                value,
+            )
+
+    return _validate
 
 
 def in_range(minimum=None, maximum=None):
@@ -316,6 +332,15 @@ class ViewConfig:
             "help": ("Show the 'world' axes, " "at a corner of the visualisation.")
         },
     )
+    axes_uc: bool = attr.ib(
+        default=False,
+        validator=instance_of(bool),
+        metadata={
+            "help": (
+                "Show the 'unit cell' axes (abc), instead of the 'world' axes (XYZ)"
+            )
+        },
+    )
     axes_length: float = attr.ib(
         default=15, validator=in_range(0), metadata={"help": "Length of axes lines."}
     )
@@ -325,8 +350,15 @@ class ViewConfig:
     axes_line_color: str = attr.ib(
         default="black", validator=is_html_color, metadata={"help": ""}
     )
+    axes_offset: Tuple[float, float] = attr.ib(
+        default=(20, 20),
+        validator=deep_iterable(instance_of((int, float)), iterable_length(2)),
+        metadata={"help": "Offset of axis origin from the bottom left of the canvas"},
+    )
     canvas_size: Tuple[float, float] = attr.ib(
-        default=(400, 400), validator=instance_of((list, tuple)), metadata={"help": ""}
+        default=(400, 400),
+        validator=deep_iterable(instance_of((int, float)), iterable_length(2)),
+        metadata={"help": ""},
     )
     canvas_color_foreground: str = attr.ib(
         default="#000000", validator=is_html_color, metadata={"help": ""}

--- a/ase_notebook/draw_utils.py
+++ b/ase_notebook/draw_utils.py
@@ -184,11 +184,11 @@ def get_miller_coordinates(cell, miller):
     return np.array(points)
 
 
-def compute_bonds(atoms, atom_radii):
+def compute_bonds(atoms, atom_radii, scale_radii=1.5):
     """Compute bonds for atoms."""
     from ase.neighborlist import NeighborList
 
-    nl = NeighborList(atom_radii * 1.5, skin=0, self_interaction=False)
+    nl = NeighborList(atom_radii * scale_radii, skin=0, self_interaction=False)
     nl.update(atoms)
     nbonds = nl.nneighbors + nl.npbcneighbors
 
@@ -230,6 +230,7 @@ def initialise_element_groups(
     show_unit_cell=True,
     uc_dash_pattern=None,
     show_bonds=False,
+    bond_radii_scale=1.5,
     bond_array_name=None,
     bond_pairs_filter=None,
     bond_supercell=(1, 1, 1),
@@ -249,6 +250,8 @@ def initialise_element_groups(
         split unit cell lines into dash pattern (line_length, gap_length)
     show_bonds : bool
         show the atomic bonds
+    bond_radii_scale : float
+        Factor to scale atomic radii by, when computing bonds (via overlapping radii)
     bond_array_name : str
         The name of a boolean array on the Atoms, specifying which atoms that bonds
         should be drawn for (if None, then all bonds are drawn).
@@ -309,7 +312,7 @@ def initialise_element_groups(
     if show_bonds:
         atomscopy = atoms.copy()
         atomscopy.cell *= np.array(bond_supercell)[:, np.newaxis]
-        bonds = compute_bonds(atomscopy, atom_radii)
+        bonds = compute_bonds(atomscopy, atom_radii, bond_radii_scale)
         if bond_array_name is not None:
             bonds = filter_bond_indices(
                 bonds, atoms.get_array(bond_array_name).tolist()

--- a/ase_notebook/viewer.py
+++ b/ase_notebook/viewer.py
@@ -1,4 +1,5 @@
 """A module for creating visualisations of a structure."""
+from copy import copy
 import json
 import subprocess
 import sys
@@ -43,6 +44,14 @@ class AseView:
             self._config = config
         else:
             self._config = ViewConfig(**kwargs)
+
+    def __copy__(self):
+        """Return a copy of this instance."""
+        return self.__class__(copy(self._config))
+
+    def copy(self):
+        """Return a copy of this instance."""
+        return self.__class__(copy(self._config))
 
     @property
     def config(self):

--- a/ase_notebook/viewer.py
+++ b/ase_notebook/viewer.py
@@ -238,6 +238,7 @@ class AseView:
             show_unit_cell=config.show_unit_cell,
             uc_dash_pattern=config.uc_dash_pattern,
             show_bonds=config.show_bonds,
+            bond_radii_scale=config.bond_radii_scale,
             bond_array_name=config.bond_array_name,
             bond_pairs_filter=config.bond_pairs_filter,
             miller_planes=config.miller_planes if config.show_miller_planes else None,

--- a/ase_notebook/viewer.py
+++ b/ase_notebook/viewer.py
@@ -389,14 +389,26 @@ class AseView:
             viewbox = (0, 0, config.canvas_size[0], config.canvas_size[1])
 
         if config.show_axes:
+            rmatrix = axes = rotation_matrix * (1, -1, 1)
+            labels = ("X", "Y", "Z")
+            if config.axes_uc:
+                # TODO add config.axes_uc to threejs render
+                axes = np.einsum("...jk,...k->...j", rmatrix.T, atoms.cell)
+                axes = np.divide(axes.T, np.linalg.norm(axes, axis=1)).T
+                labels = ("a", "b", "c")
             svg_elements.extend(
                 create_axes_elements(
-                    rotation_matrix * (1, -1, 1),
+                    axes,
                     config.canvas_size,
-                    inset=(20 + left, 20 + bottom),
+                    # TODO compute offset based on axes xs and ys
+                    inset=(
+                        config.axes_offset[0] + left,
+                        config.axes_offset[1] + bottom,
+                    ),
                     length=config.axes_length,
                     font_size=config.axes_font_size,
                     line_color=config.axes_line_color,
+                    labels=labels,
                 )
             )
 

--- a/ase_notebook/viewer.py
+++ b/ase_notebook/viewer.py
@@ -222,6 +222,8 @@ class AseView:
             show_unit_cell=config.show_unit_cell,
             uc_dash_pattern=config.uc_dash_pattern,
             show_bonds=config.show_bonds,
+            bond_array_name=config.bond_array_name,
+            bond_pairs_filter=config.bond_pairs_filter,
             miller_planes=config.miller_planes if config.show_miller_planes else None,
             miller_planes_as_lines=config.miller_as_lines,
         )
@@ -258,7 +260,10 @@ class AseView:
             {
                 "color": atom_colors,
                 "label": [
-                    None if g or not config.atom_show_label else l
+                    None
+                    if (g and not config.ghost_show_label)
+                    or (not config.atom_show_label)
+                    else l
                     for l, g in zip(atom_labels, ghost_atoms)
                 ],
                 "ghost": ghost_atoms,

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,12 @@ setup(
             "flake8_builtins",
             "import-order",
         ],
-        "docs": ["sphinx>=1.8", "sphinx_rtd_theme", "ipypublish>=0.10.10", "ipython"],
+        "docs": [
+            "sphinx>=1.8,<3",
+            "sphinx_rtd_theme",
+            "ipypublish>=0.10.10",
+            "ipython",
+        ],
     },
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/test_draw_utils.py
+++ b/tests/test_draw_utils.py
@@ -1,4 +1,5 @@
 """Tests for ``ase_notebook.gui``."""
+from ase import Atoms
 import numpy as np
 import pytest
 
@@ -91,3 +92,91 @@ def test_get_miller_coordinates(miller, expected):
         [[1, 0, 0], [0, 2, 0], [0, 0, 3]], miller
     )
     assert points.tolist() == expected
+
+
+def test_compute_bonds():
+    """Test bonds are correctly computed (no PBC)."""
+    atoms = Atoms(
+        numbers=[1, 2, 3],
+        positions=[[0, 0, 0], [0.2, 0.2, 0.2], [0.5, 0.5, 0.5]],
+        cell=np.eye(3),
+        pbc=False,
+    )
+    atom_radii = np.array([0.4, 0.4, 0.4])
+
+    bonds = draw_utils.compute_bonds(atoms, atom_radii)
+    # print(bonds.tolist())
+    assert np.allclose(bonds, [[0, 1, 0, 0, 0], [0, 2, 0, 0, 0], [1, 2, 0, 0, 0]])
+
+
+def test_compute_bonds_pbc():
+    """Test bonds are correctly computed (with PBC)."""
+    atoms = Atoms(numbers=[1], positions=[[0, 0, 0]], cell=np.eye(3), pbc=True)
+    atom_radii = np.array([0.4])
+
+    bonds = draw_utils.compute_bonds(atoms, atom_radii)
+    # print(bonds.tolist())
+    assert np.allclose(
+        bonds,
+        [
+            [0, 0, 0, 0, 1],
+            [0, 0, 0, 1, 0],
+            [0, 0, 1, 0, 0],
+            [0, 0, 0, 0, -1],
+            [0, 0, 0, -1, 0],
+            [0, 0, -1, 0, 0],
+        ],
+    )
+
+
+def test_compute_bonds_filter_by_index():
+    """Test filtering of bonds by atom indices."""
+    atoms = Atoms(
+        numbers=[1, 2], positions=[[0, 0, 0], [0.5, 0.5, 0.5]], cell=np.eye(3), pbc=True
+    )
+    # atoms.set_array("bonds", np.array([False, True]))
+    atom_radii = np.array([0.4, 0.4])
+    bonds = draw_utils.compute_bonds(atoms, atom_radii)
+    bonds = draw_utils.filter_bond_indices(bonds, [False, True])
+
+    # print(bonds.tolist())
+    assert np.allclose(
+        bonds,
+        [
+            [0, 1, 0, 0, 0],
+            [1, 0, 0, 0, 1],
+            [1, 1, 0, 0, 1],
+            [1, 0, 0, 1, 0],
+            [1, 1, 0, 1, 0],
+            [1, 0, 0, 1, 1],
+            [1, 0, 1, 0, 0],
+            [1, 1, 1, 0, 0],
+            [1, 0, 1, 0, 1],
+            [1, 0, 1, 1, 0],
+            [1, 0, 1, 1, 1],
+            [1, 1, 0, 0, -1],
+            [1, 1, 0, -1, 0],
+            [1, 1, -1, 0, 0],
+        ],
+    )
+
+
+def test_compute_bonds_filter_element_pairs():
+    """Test filtering of bonds by element pairs."""
+    atoms = Atoms(
+        symbols=["H", "He", "Mg"],
+        positions=[[0, 0, 0], [0.2, 0.2, 0.2], [0.5, 0.5, 0.5]],
+        cell=np.eye(3),
+        pbc=False,
+    )
+    atom_radii = np.array([0.4, 0.4, 0.4])
+
+    bonds = draw_utils.compute_bonds(atoms, atom_radii)
+
+    allowed = [("H", "Mg")]
+    allowed = set([(a, b) for a, b in allowed] + [(b, a) for a, b in allowed])
+    symbols = atoms.get_chemical_symbols()
+    bonds = bonds[[(symbols[i], symbols[j]) in allowed for i, j in bonds[:, 0:2]]]
+
+    # print(bonds.tolist())
+    assert np.allclose(bonds, [[0, 2, 0, 0, 0]])


### PR DESCRIPTION
This PR introduces additional configuration/functionality for visualising bonds:

- `bond_radii_scale`: Factor to scale atomic radii by, when computing bonds (via overlapping radii)
- `bond_array_name`: The name of a boolean array on the `ase.Atoms`, specifying which atoms that bonds should be drawn for
- `bond_pairs_filter`: A list of bond element pairs to filter by
- `bond_color_by`: How to color bond: 'atoms' (same as connecting atoms) or 'length'
- `bond_colormap`: The matplotlib colormap to use with ``bond_color_by='length'`
- `bond_colormap_range`: The matplotlib colormap normalisation to use with ``bond_color_by='length'``

Also, document testing was moved to CircleCI